### PR TITLE
Dropped superfluos "for" attribute

### DIFF
--- a/src/collective/mustread/behaviors/configure.zcml
+++ b/src/collective/mustread/behaviors/configure.zcml
@@ -19,7 +19,6 @@
       title="Maybe Must Read"
       description="Per-content object choice whether this object MUST be read"
       provides=".maybe.IMaybeMustRead"
-      for="plone.dexterity.interfaces.IDexterityContent"
       />
   
 </configure>


### PR DESCRIPTION
Silences warning

    plone.behavior Specifying 'for' in behavior 'Maybe Must Read' if no 'factory' is given has no effect and is superfluous.