### PR TITLE
Fix the most_read method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- The ``most_read`` method does not break when trying to fetch objects
+  that the user cannot view. Fixes #14 [ale-rt]
 
 
 2.0.0 (2020-01-27)

--- a/src/collective/mustread/tests/test_tracker.py
+++ b/src/collective/mustread/tests/test_tracker.py
@@ -117,6 +117,14 @@ class TestTrackerTrending(FunctionalBaseTestCase):
         expect = [x[1] for x in sorted(self.pages, reverse=True)]
         self.assertEqual(result, expect)
 
+    def test_most_read_does_not_choke_with_private_objects(self):
+        for (i, page) in self.pages:
+            for y in range(i):  # page01 1 read, page02 2 reads, etc
+                self.tracker.mark_read(page, userid='user%02d' % (y + 1))
+        logout()
+        result = list(self.tracker.most_read())
+        self.assertListEqual(result, [])
+
     def test_most_read_applies_status_filter(self):
         for (i, page) in self.pages:
             if not i % 2:  # only read even pages

--- a/src/collective/mustread/tracker.py
+++ b/src/collective/mustread/tracker.py
@@ -99,7 +99,12 @@ class Tracker(object):
                      .order_by(func.count(MustRead.userid).desc())\
                      .limit(limit)
         for record in self.query_all(query):
-            yield api.content.get(UID=record.uid)
+            try:
+                obj = api.content.get(UID=record.uid)
+            except Exception:
+                obj = None
+            if obj is not None:
+                yield obj
 
     def schedule_must_read(self, obj, userids, deadline, by=None):
         path = '/'.join(obj.getPhysicalPath())


### PR DESCRIPTION
The ``most_read`` method does not break when trying to fetch objects that the user cannot view.

Fixes #14