### PR TITLE
Fix a deprecation warning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog
 2.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix a deprecation warning [ale-rt]
 
 
 2.0.1 (2021-05-20)

--- a/src/collective/mustread/browser/init_db.py
+++ b/src/collective/mustread/browser/init_db.py
@@ -37,7 +37,7 @@ class InitView(BrowserView):
         if not record or 'memory' in record:
             dbpath = '%s/var/mustread.db' % os.getcwd()
             record = u'sqlite:///%s' % dbpath
-            logger.warn(
+            logger.warning(
                 'SQL storage not properly configured. Forcing: %s', record)
             api.portal.set_registry_record(
                 'connectionstring', record, interface=IMustReadSettings)

--- a/src/collective/mustread/db.py
+++ b/src/collective/mustread/db.py
@@ -59,7 +59,7 @@ def getEngine(conn_string=None, conn_parameters=None, req=None):
                 conn_parameters = loads(conn_parameters)
             engine = create_engine(conn_string, **conn_parameters)
             if 'memory' in conn_string:
-                log.warn(
+                log.warning(
                     'Running a in-memory database is NOT recommended '
                     'for production. Please check the registry setting '
                     'collective.mustread.interfaces.IMustReadSettings.')

--- a/src/collective/mustread/upgrades/to1001.py
+++ b/src/collective/mustread/upgrades/to1001.py
@@ -29,7 +29,9 @@ def update_dbschema(context):
     record = api.portal.get_registry_record(
         'collective.mustread.interfaces.IMustReadSettings.connectionstring')
     if record and not record.startswith('sqlite://'):
-        logger.warn('database migration is only tested for sqlite databases')
+        logger.warning(
+            "database migration is only tested for sqlite databases"
+        )
 
     engine = db.getEngine()
     for statement in (


### PR DESCRIPTION
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead